### PR TITLE
Use primary track momentum when available and tighten DCA cut

### DIFF
--- a/StEventPlane/StEventPlane.cxx
+++ b/StEventPlane/StEventPlane.cxx
@@ -232,6 +232,7 @@ int StEventPlane::calculateEventPlane()
       }
 
       if (picoTrack->nHitsFit() < EventPlaneConstants::nHitsFitMin) continue;
+      if(1.*picoTrack->nHitsFit()/picoTrack->nHitsMax() < EventPlaneConstants::mNHitsFitRatioMin) continue;
 
       StPhysicalHelix helix = picoTrack->dcaGeometry().helix();
       float dca = helix.geometricSignedDistance(mVertexPos);
@@ -239,8 +240,16 @@ int StEventPlane::calculateEventPlane()
 
       float pathLengthToPrimaryVertex = helix.pathLength(mVertexPos.x(), mVertexPos.y());
       StThreeVectorF momentum = helix.momentumAt(pathLengthToPrimaryVertex, mBField * kilogauss);
-      float pt = momentum.perp();
-      float eta = momentum.pseudoRapidity();
+      //SL16d 
+      double eta, pt;
+      if( picoTrack->pMom().perp() > 0 ){
+	eta =picoTrack->pMom().pseudoRapidity();
+	pt =picoTrack->pMom().perp();
+      }
+      else{
+	pt = momentum.perp();
+	eta = momentum.pseudoRapidity();
+      }
       if (fabs(eta) > EventPlaneConstants::etaMaxEventPlane) continue;
       if (pt < EventPlaneConstants::ptMinEventPlane || pt > EventPlaneConstants::ptMaxEventPlane) continue;
 
@@ -272,6 +281,7 @@ int StEventPlane::calculateEventPlane()
 
       if (mAcceptEvent) hNHitsFit->Fill(picoTrack->nHitsFit());
       if (picoTrack->nHitsFit() < EventPlaneConstants::nHitsFitMin) continue;
+      if(1.*picoTrack->nHitsFit()/picoTrack->nHitsMax() < EventPlaneConstants::mNHitsFitRatioMin) continue;
 
       StPhysicalHelix helix = picoTrack->dcaGeometry().helix();
       float dca = helix.geometricSignedDistance(mVertexPos);
@@ -280,9 +290,19 @@ int StEventPlane::calculateEventPlane()
 
       float pathLengthToPrimaryVertex = helix.pathLength(mVertexPos.x(), mVertexPos.y());
       StThreeVectorF momentum = helix.momentumAt(pathLengthToPrimaryVertex, mBField * kilogauss);
-      float pt = momentum.perp();
-      float eta = momentum.pseudoRapidity();
-      float phi = momentum.phi();
+      //SL16d
+      double eta, pt, phi;
+      if( picoTrack->pMom().perp() > 0 ){
+	eta =picoTrack->pMom().pseudoRapidity();
+	pt =picoTrack->pMom().perp();
+	phi =picoTrack->pMom().phi();
+      }
+      else{
+	pt = momentum.perp();
+	eta = momentum.pseudoRapidity();
+	phi = momentum.phi();
+      }
+
       if (mAcceptEvent) hEta->Fill(eta);
       if (mAcceptEvent) hPt->Fill(pt);
       if (fabs(eta) > EventPlaneConstants::etaMaxEventPlane) continue;

--- a/StEventPlane/StEventPlaneConstants.h
+++ b/StEventPlane/StEventPlaneConstants.h
@@ -20,21 +20,21 @@ namespace EventPlaneConstants
   int const mTriggerId[nTrig] = {450050, 450060,
 				 450005, 450015,
 				 450025 };
-  //test
-  TString qVectorRunDir = " /global/homes/m/mlomnitz/mlomnitz_projectdir/Run14_Reprod/recenter_v2_2/qVectorRun_v2_v3";
-  //TString qVectorRunDir = " /global/homes/m/mlomnitz/mlomnitz_projectdir/Run14_Reprod/recenter_v2_2/qVectorRun";
-   TString qVectorDayDir = " /global/homes/m/mlomnitz/mlomnitz_projectdir/Run14_Reprod/recenter_v2_2/qVectorDay_v2_v3";
+
+  //SL16d prduction
+  TString qVectorRunDir ="/global/homes/m/mlomnitz/mlomnitz_projectdir/Run14_Reprod/recenter_v2_2/qVectorRun_v2_v3_2016-07-28";
+   TString qVectorDayDir = "/global/homes/m/mlomnitz/mlomnitz_projectdir/Run14_Reprod/recenter_v2_2/qVectorDay_v2_v3_2016-07-28";
    //Event Cuts
    float const vzMax = 6.0;
    float const deltaVzMax = 3.0;
 
    //Track Cuts
    int const nHitsFitMin = 15;
-
+   float const mNHitsFitRatioMin = 0.52;
    //Track cuts for event plane
    float const etaMaxEventPlane = 1.0;
-   float const ptMinEventPlane  = 0.15;
+   float const ptMinEventPlane  = 0.2;
    float const ptMaxEventPlane  = 2.0;
-   float const dcaMaxEventPlane = 3.0;
+   float const dcaMaxEventPlane = 1.0;
 }
 #endif


### PR DESCRIPTION
Small changes to run re-centering in SL16d consistent with qVector definition
